### PR TITLE
Change action wrappers to return multiple errors by join

### DIFF
--- a/parallel_map_action.go
+++ b/parallel_map_action.go
@@ -2,12 +2,12 @@ package chain
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	internalErrors "github.com/JSYoo5B/chain/internal/errors"
 	"github.com/JSYoo5B/chain/internal/logger"
 	"maps"
 	"runtime/debug"
-	"sync"
 )
 
 // AsParallelMapAction creates an Action that processes a map's values in parallel.
@@ -38,8 +38,13 @@ func (p parallelMapAction[K, T]) Run(ctx context.Context, input map[K]T) (output
 	output = make(map[K]T)
 	maps.Copy(output, input)
 
-	wg := sync.WaitGroup{}
-	wg.Add(len(input))
+	type result struct {
+		key    K
+		output T
+		err    error
+	}
+
+	results := make(chan result, len(input))
 	runKey := func(k K, in T) {
 		logger.Debugf(pCtx, "chain: running key `%v`", k)
 		c := logger.WithRunnerDepth(ctx, fmt.Sprintf("%s[%v]/%s", p.name, k, p.action.Name()))
@@ -51,9 +56,11 @@ func (p parallelMapAction[K, T]) Run(ctx context.Context, input map[K]T) (output
 				logger.Errorf(pCtx, "chain: panic occurred on running key %v, caused by %v", k, panicErr)
 				debug.PrintStack()
 
-				output[k] = in
-				err = internalErrors.NewPanicError(runnerName, panicErr)
-				wg.Done()
+				results <- result{
+					key:    k,
+					output: in,
+					err:    internalErrors.NewPanicError(runnerName, panicErr),
+				}
 				return
 			}
 		}()
@@ -61,15 +68,22 @@ func (p parallelMapAction[K, T]) Run(ctx context.Context, input map[K]T) (output
 		out, e := p.action.Run(c, in)
 		if e != nil {
 			logger.Errorf(pCtx, "chain: error occurred in key `%v`: %v", k, e)
-			err = e
 		}
-		output[k] = out
-		wg.Done()
+		results <- result{
+			key:    k,
+			output: out,
+			err:    e,
+		}
 	}
 	for k, in := range input {
 		go runKey(k, in)
 	}
-	wg.Wait()
+
+	for range len(input) {
+		r := <-results
+		output[r.key] = r.output
+		err = errors.Join(err, r.err)
+	}
 
 	return output, err
 }

--- a/parallel_map_action_test.go
+++ b/parallel_map_action_test.go
@@ -3,6 +3,7 @@ package chain
 import (
 	"context"
 	"errors"
+	"fmt"
 	"github.com/JSYoo5B/chain/internal/logger"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -52,6 +53,50 @@ func TestParallelMapAction(t *testing.T) {
 		output, err := doubles.Run(context.Background(), input)
 
 		assert.Error(t, err)
+		assert.Equal(t, expected, output)
+	})
+	t.Run("multiple errors are joined", func(t *testing.T) {
+		failSmallNumbers := NewSimpleAction(
+			"failSmallNumbers",
+			func(_ context.Context, input int) (int, error) {
+				if input < 2 {
+					return input, fmt.Errorf("bad input: %d", input)
+				}
+				return input * 2, nil
+			})
+		doubles := AsParallelMapAction[string, int]("MapDoubleWithErrors", failSmallNumbers)
+		input := map[string]int{"zero": 0, "one": 1, "two": 2, "three": 3}
+		expected := map[string]int{"zero": 0, "one": 1, "two": 4, "three": 6}
+
+		output, err := doubles.Run(context.Background(), input)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "bad input: 0")
+		assert.Contains(t, err.Error(), "bad input: 1")
+		assert.Equal(t, expected, output)
+	})
+	t.Run("panic and error are joined", func(t *testing.T) {
+		failAndPanic := NewSimpleAction(
+			"failAndPanic",
+			func(_ context.Context, input int) (int, error) {
+				switch input {
+				case 0:
+					return input, fmt.Errorf("bad input: %d", input)
+				case 1:
+					panic("panic input: 1")
+				default:
+					return input * 2, nil
+				}
+			})
+		doubles := AsParallelMapAction[string, int]("MapDoubleWithPanicAndError", failAndPanic)
+		input := map[string]int{"zero": 0, "one": 1, "two": 2}
+		expected := map[string]int{"zero": 0, "one": 1, "two": 4}
+
+		output, err := doubles.Run(context.Background(), input)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "bad input: 0")
+		assert.Contains(t, err.Error(), "panic input: 1")
 		assert.Equal(t, expected, output)
 	})
 	t.Run("panic in parallel iteration", func(t *testing.T) {

--- a/parallel_slice_action.go
+++ b/parallel_slice_action.go
@@ -2,11 +2,11 @@ package chain
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	internalErrors "github.com/JSYoo5B/chain/internal/errors"
 	"github.com/JSYoo5B/chain/internal/logger"
 	"runtime/debug"
-	"sync"
 )
 
 // AsParallelSliceAction creates an Action that processes a slice's elements in parallel.
@@ -37,8 +37,13 @@ func (p parallelSliceAction[T]) Run(ctx context.Context, input []T) (output []T,
 	output = make([]T, len(input))
 	copy(output, input)
 
-	wg := sync.WaitGroup{}
-	wg.Add(len(input))
+	type result struct {
+		index  int
+		output T
+		err    error
+	}
+
+	results := make(chan result, len(input))
 	runIndex := func(i int, in T) {
 		logger.Debugf(pCtx, "chain: running index %d", i)
 
@@ -51,9 +56,11 @@ func (p parallelSliceAction[T]) Run(ctx context.Context, input []T) (output []T,
 				logger.Errorf(pCtx, "chain: panic occurred on running index %d, caused by %v", i, panicErr)
 				debug.PrintStack()
 
-				output[i] = in
-				err = internalErrors.NewPanicError(runnerName, panicErr)
-				wg.Done()
+				results <- result{
+					index:  i,
+					output: in,
+					err:    internalErrors.NewPanicError(runnerName, panicErr),
+				}
 				return
 			}
 		}()
@@ -61,15 +68,22 @@ func (p parallelSliceAction[T]) Run(ctx context.Context, input []T) (output []T,
 		out, e := p.action.Run(c, in)
 		if e != nil {
 			logger.Errorf(pCtx, "chain: error occurred in index %d: %v", i, e)
-			err = e
 		}
-		output[i] = out
-		wg.Done()
+		results <- result{
+			index:  i,
+			output: out,
+			err:    e,
+		}
 	}
 	for i, in := range input {
 		go runIndex(i, in)
 	}
-	wg.Wait()
+
+	for range len(input) {
+		r := <-results
+		output[r.index] = r.output
+		err = errors.Join(err, r.err)
+	}
 
 	return output, err
 }

--- a/parallel_slice_action_test.go
+++ b/parallel_slice_action_test.go
@@ -3,6 +3,7 @@ package chain
 import (
 	"context"
 	"errors"
+	"fmt"
 	"github.com/JSYoo5B/chain/internal/logger"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -52,6 +53,50 @@ func TestParallelSliceAction(t *testing.T) {
 		output, err := doubles.Run(context.Background(), input)
 
 		assert.Error(t, err)
+		assert.Equal(t, expected, output)
+	})
+	t.Run("multiple errors are joined", func(t *testing.T) {
+		failSmallNumbers := NewSimpleAction(
+			"failSmallNumbers",
+			func(_ context.Context, input int) (int, error) {
+				if input < 2 {
+					return input, fmt.Errorf("bad input: %d", input)
+				}
+				return input * 2, nil
+			})
+		doubles := AsParallelSliceAction("MapDoubleWithErrors", failSmallNumbers)
+		input := []int{0, 1, 2, 3}
+		expected := []int{0, 1, 4, 6}
+
+		output, err := doubles.Run(context.Background(), input)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "bad input: 0")
+		assert.Contains(t, err.Error(), "bad input: 1")
+		assert.Equal(t, expected, output)
+	})
+	t.Run("panic and error are joined", func(t *testing.T) {
+		failAndPanic := NewSimpleAction(
+			"failAndPanic",
+			func(_ context.Context, input int) (int, error) {
+				switch input {
+				case 0:
+					return input, fmt.Errorf("bad input: %d", input)
+				case 1:
+					panic("panic input: 1")
+				default:
+					return input * 2, nil
+				}
+			})
+		doubles := AsParallelSliceAction("MapDoubleWithPanicAndError", failAndPanic)
+		input := []int{0, 1, 2}
+		expected := []int{0, 1, 4}
+
+		output, err := doubles.Run(context.Background(), input)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "bad input: 0")
+		assert.Contains(t, err.Error(), "panic input: 1")
 		assert.Equal(t, expected, output)
 	})
 	t.Run("panic in parallel iteration", func(t *testing.T) {

--- a/retryable_action.go
+++ b/retryable_action.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	internalErrors "github.com/JSYoo5B/chain/internal/errors"
 	"github.com/JSYoo5B/chain/internal/logger"
@@ -76,12 +77,25 @@ func (r retryableAction[T]) Run(ctx context.Context, input T) (output T, err err
 
 		if r.rollbackAction != nil && attempt < r.maxRetry {
 			logger.Debugf(pCtx, "chain: rolling back with %s", r.rollbackAction.Name())
-			output, err = r.rollbackAction.Run(rCtx, output)
-			if err != nil {
-				return output, fmt.Errorf("rolling back failed: %w", err)
+			var rollbackErr error
+			output, rollbackErr = runRollbackAction(rCtx, r.rollbackAction, output)
+			if rollbackErr != nil {
+				return output, errors.Join(err, fmt.Errorf("rolling back failed: %w", rollbackErr))
 			}
 		}
 	}
 
 	return output, err
+}
+
+func runRollbackAction[T any](ctx context.Context, rollbackAction Action[T], input T) (output T, err error) {
+	output = input
+	runnerName, _ := logger.RunnerNameFromContext(ctx)
+	defer func() {
+		if panicErr := recover(); panicErr != nil {
+			err = internalErrors.NewPanicError(runnerName, panicErr)
+		}
+	}()
+
+	return rollbackAction.Run(ctx, input)
 }

--- a/retryable_action_test.go
+++ b/retryable_action_test.go
@@ -3,8 +3,10 @@ package chain
 import (
 	"context"
 	"fmt"
+	"github.com/JSYoo5B/chain/internal/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"strings"
 	"testing"
 )
 
@@ -55,6 +57,56 @@ func TestRetryableAction(t *testing.T) {
 	})
 }
 
+func TestRetryableAction_RollbackError(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+
+	checkZero := NewSimpleAction(
+		"checkZero",
+		func(ctx context.Context, input int) (int, error) {
+			if input == 0 {
+				return input, nil
+			}
+			return input, fmt.Errorf("%d is not zero", input)
+		})
+
+	t.Run("rollback error preserves main action error", func(t *testing.T) {
+		rollbackFails := NewSimpleAction(
+			"rollbackFails",
+			func(_ context.Context, input int) (int, error) {
+				return input - 1, fmt.Errorf("rollback failed")
+			})
+		expectZero := AsRetryableAction("expectZero", checkZero, rollbackFails, 3)
+
+		output, err := expectZero.Run(context.Background(), 2)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "2 is not zero")
+		assert.Contains(t, err.Error(), "rolling back failed")
+		assert.Contains(t, err.Error(), "rollback failed")
+		assertLessIndex(t, err.Error(), "2 is not zero", "rolling back failed")
+		assert.Equal(t, 1, output)
+	})
+
+	t.Run("rollback panic preserves main action error", func(t *testing.T) {
+		rollbackPanics := NewSimpleAction(
+			"rollbackPanics",
+			func(_ context.Context, input int) (int, error) {
+				panic("rollback panic")
+			})
+		expectZero := AsRetryableAction("expectZero", checkZero, rollbackPanics, 3)
+
+		output, err := expectZero.Run(context.Background(), 2)
+
+		var panicErr *errors.PanicError
+		assert.Error(t, err)
+		assert.ErrorAs(t, err, &panicErr)
+		assert.Contains(t, err.Error(), "2 is not zero")
+		assert.Contains(t, err.Error(), "rollback panic")
+		assertLessIndex(t, err.Error(), "2 is not zero", "rollback panic")
+		assert.Equal(t, 2, output)
+	})
+}
+
 func TestRetryableAction_withoutRollback(t *testing.T) {
 	logrus.SetLevel(logrus.DebugLevel)
 
@@ -95,4 +147,14 @@ func TestRetryableAction_withoutRollback(t *testing.T) {
 		assert.Error(t, err)
 		assert.NotEqual(t, 0, output)
 	})
+}
+
+func assertLessIndex(t *testing.T, s, before, after string) {
+	t.Helper()
+
+	beforeIndex := strings.Index(s, before)
+	afterIndex := strings.Index(s, after)
+	if assert.NotEqual(t, -1, beforeIndex) && assert.NotEqual(t, -1, afterIndex) {
+		assert.Less(t, beforeIndex, afterIndex)
+	}
 }

--- a/sequence_map_action.go
+++ b/sequence_map_action.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	internalErrors "github.com/JSYoo5B/chain/internal/errors"
 	"github.com/JSYoo5B/chain/internal/logger"
@@ -43,7 +44,7 @@ func (s sequenceMapAction[K, T]) Run(ctx context.Context, input map[K]T) (output
 			logger.Errorf(pCtx, "chain: panic occurred on running, caused by %v", panicErr)
 			debug.PrintStack()
 
-			err = internalErrors.NewPanicError(runnerName, panicErr)
+			err = errors.Join(err, internalErrors.NewPanicError(runnerName, panicErr))
 		}
 	}()
 
@@ -56,7 +57,7 @@ func (s sequenceMapAction[K, T]) Run(ctx context.Context, input map[K]T) (output
 		out, e := s.action.Run(c, in)
 		if e != nil {
 			logger.Errorf(pCtx, "chain: error occurred in key `%v`: %v", k, e)
-			err = e
+			err = errors.Join(err, fmt.Errorf("error occurred at key `%v`: %w", k, e))
 		}
 		output[k] = out
 	}

--- a/sequence_map_action_test.go
+++ b/sequence_map_action_test.go
@@ -54,6 +54,27 @@ func TestSequenceMapAction(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, expected, output)
 	})
+	t.Run("multiple errors in iteration are joined", func(t *testing.T) {
+		onlyPositive := NewSimpleAction(
+			"onlyPositive",
+			func(_ context.Context, input int) (int, error) {
+				if input < 0 {
+					return 0, errors.New("negative input")
+				}
+				return input, nil
+			})
+		action := AsSequenceMapAction[string, int]("Sequence", onlyPositive)
+		input := map[string]int{"one": 1, "minusOne": -1, "two": 2, "minusTwo": -2}
+		expected := map[string]int{"one": 1, "minusOne": 0, "two": 2, "minusTwo": 0}
+
+		output, err := action.Run(context.Background(), input)
+
+		assert.Error(t, err)
+		assert.Equal(t, expected, output)
+		assert.Contains(t, err.Error(), "key `minusOne`")
+		assert.Contains(t, err.Error(), "key `minusTwo`")
+		assert.Contains(t, err.Error(), "negative input")
+	})
 	t.Run("panic in iteration", func(t *testing.T) {
 		divides := AsSequenceMapAction[string, int]("MapDivide10", divide10)
 		input := map[string]int{"ten": 10, "five": 5, "two": 2, "zero": 0, "one": 1}

--- a/sequence_slice_action.go
+++ b/sequence_slice_action.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	internalErrors "github.com/JSYoo5B/chain/internal/errors"
 	"github.com/JSYoo5B/chain/internal/logger"
@@ -46,7 +47,7 @@ func (s sequenceSliceAction[T]) Run(ctx context.Context, input []T) (output []T,
 			logger.Errorf(pCtx, "chain: panic occurred on running, caused by %v", panicErr)
 			debug.PrintStack()
 
-			err = internalErrors.NewPanicError(runnerName, panicErr)
+			err = errors.Join(err, internalErrors.NewPanicError(runnerName, panicErr))
 		}
 	}()
 
@@ -61,11 +62,11 @@ func (s sequenceSliceAction[T]) Run(ctx context.Context, input []T) (output []T,
 		if e != nil {
 			if s.stopOnError {
 				logger.Errorf(pCtx, "chain: stopping after error in index %d", i)
-				return output, e
+				return output, fmt.Errorf("error occurred at index %d: %w", i, e)
 
 			} else {
 				logger.Errorf(pCtx, "chain: error occurred in index %d: %v", i, e)
-				err = e
+				err = errors.Join(err, fmt.Errorf("error occurred at index %d: %w", i, e))
 			}
 		}
 	}

--- a/sequence_slice_action_test.go
+++ b/sequence_slice_action_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/JSYoo5B/chain/internal/logger"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"strings"
 	"testing"
 )
 
@@ -63,6 +64,47 @@ func TestSequenceSliceAction(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Equal(t, expected, output)
+	})
+	t.Run("multiple errors in iteration are joined in order", func(t *testing.T) {
+		onlyPositive := NewSimpleAction(
+			"onlyPositive",
+			func(_ context.Context, input int) (int, error) {
+				if input < 0 {
+					return 0, errors.New("negative input")
+				}
+				return input, nil
+			})
+		action := AsSequenceSliceAction("Sequence", onlyPositive, false)
+		input := []int{1, -1, 2, -2, 3}
+		expected := []int{1, 0, 2, 0, 3}
+
+		output, err := action.Run(context.Background(), input)
+
+		assert.Error(t, err)
+		assert.Equal(t, expected, output)
+		assert.Contains(t, err.Error(), "negative input")
+		assert.Less(t, strings.Index(err.Error(), "index 1"), strings.Index(err.Error(), "index 3"))
+	})
+	t.Run("error before panic is preserved", func(t *testing.T) {
+		failOrDivide := NewSimpleAction(
+			"failOrDivide",
+			func(_ context.Context, input int) (int, error) {
+				if input < 0 {
+					return 0, errors.New("negative input")
+				}
+				return 10 / input, nil
+			})
+		action := AsSequenceSliceAction("Sequence", failOrDivide, false)
+		input := []int{10, -1, 5, 0, 1}
+		expected := []int{1, 0, 2, 0, 1}
+
+		output, err := action.Run(context.Background(), input)
+
+		assert.Error(t, err)
+		assert.Equal(t, expected, output)
+		assert.Contains(t, err.Error(), "negative input")
+		assert.Contains(t, err.Error(), "divide by zero")
+		assert.Less(t, strings.Index(err.Error(), "negative input"), strings.Index(err.Error(), "divide by zero"))
 	})
 	t.Run("panic in iteration", func(t *testing.T) {
 		divides := AsSequenceSliceAction("MapDivide10", divide10, false)

--- a/simple_branch_action.go
+++ b/simple_branch_action.go
@@ -30,10 +30,13 @@ func NewSimpleBranchAction[T any](name string, runFunc RunFunc[T], directions []
 	if runFunc == nil {
 		runFunc = func(_ context.Context, input T) (T, error) { return input, nil }
 	}
+	copiedDirections := make([]string, len(directions))
+	copy(copiedDirections, directions)
+
 	return &simpleBranchAction[T]{
 		name:       name,
 		runFunc:    runFunc,
-		directions: directions,
+		directions: copiedDirections,
 		branchFunc: branchFunc,
 	}
 }
@@ -45,8 +48,12 @@ type simpleBranchAction[T any] struct {
 	branchFunc BranchFunc[T]
 }
 
-func (s simpleBranchAction[T]) Name() string         { return s.name }
-func (s simpleBranchAction[T]) Directions() []string { return s.directions }
+func (s simpleBranchAction[T]) Name() string { return s.name }
+func (s simpleBranchAction[T]) Directions() []string {
+	directions := make([]string, len(s.directions))
+	copy(directions, s.directions)
+	return directions
+}
 func (s simpleBranchAction[T]) Run(ctx context.Context, input T) (output T, err error) {
 	return s.runFunc(ctx, input)
 }

--- a/simple_branch_action_test.go
+++ b/simple_branch_action_test.go
@@ -1,0 +1,32 @@
+package chain
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSimpleBranchAction_Directions(t *testing.T) {
+	branchFunc := func(_ context.Context, _ int) (string, error) {
+		return "left", nil
+	}
+
+	t.Run("constructor copies directions", func(t *testing.T) {
+		directions := []string{"left", "right"}
+		action := NewSimpleBranchAction("branch", nil, directions, branchFunc)
+
+		directions[0] = "changed"
+
+		assert.Equal(t, []string{"left", "right"}, action.Directions())
+	})
+
+	t.Run("directions returns copy", func(t *testing.T) {
+		action := NewSimpleBranchAction("branch", nil, []string{"left", "right"}, branchFunc)
+		directions := action.Directions()
+
+		directions[0] = "changed"
+
+		assert.Equal(t, []string{"left", "right"}, action.Directions())
+	})
+}

--- a/workflow_run.go
+++ b/workflow_run.go
@@ -30,7 +30,7 @@ func (w *Workflow[T]) Run(ctx context.Context, input T) (output T, err error) {
 // the plan specifies otherwise.
 // If no action plan is found for a given direction,
 // the Workflow will terminate with the appropriate error.
-func (w *Workflow[T]) RunAt(initAction Action[T], ctx context.Context, input T) (output T, lastErr error) {
+func (w *Workflow[T]) RunAt(initAction Action[T], ctx context.Context, input T) (output T, err error) {
 	if !isMemberActionInWorkflow(initAction, w) {
 		return input, errors.New("given initAction is not registered on constructor")
 	}
@@ -48,12 +48,15 @@ func (w *Workflow[T]) RunAt(initAction Action[T], ctx context.Context, input T) 
 	logger.Debugf(ctx, "chain: start running with `%s`", initAction.Name())
 	for currentAction = initAction; currentAction != nil; currentAction = nextAction {
 		output, direction, runErr = runAction(currentAction, ctx, input)
+		if runErr != nil {
+			err = errors.Join(err, runErr)
+		}
 
 		nextAction, selectErr = selectNextAction(w.runPlans[currentAction], currentAction, direction)
 		if selectErr != nil {
 			logger.Error(ctx, selectErr)
 			direction = Abort
-			lastErr = selectErr
+			err = errors.Join(err, selectErr)
 			break
 		}
 
@@ -64,15 +67,8 @@ func (w *Workflow[T]) RunAt(initAction Action[T], ctx context.Context, input T) 
 		logger.Debugf(ctx, "chain: `%s` directs `%s`, selecting `%s`", currentAction.Name(), direction, nextActionName)
 
 		input = output
-		if runErr != nil {
-			lastErr = runErr
-		}
 	}
-	if lastErr != nil && direction != Abort {
-		direction = Failure
-	}
-
-	return output, lastErr
+	return output, err
 }
 
 func selectNextAction[T any](plan RunPlan[T], currentAction Action[T], direction string) (nextAction Action[T], err error) {

--- a/workflow_run_test.go
+++ b/workflow_run_test.go
@@ -2,8 +2,10 @@ package chain
 
 import (
 	"context"
+	"errors"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"strings"
 	"testing"
 )
 
@@ -131,4 +133,27 @@ func TestPanicPropagation(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestWorkflow_RunAtErrorAggregation(t *testing.T) {
+	firstErr := errors.New("first action failed")
+	secondErr := errors.New("second action failed")
+	first := NewSimpleAction(
+		"first",
+		func(_ context.Context, input int) (int, error) { return input + 1, firstErr },
+	)
+	second := NewSimpleAction(
+		"second",
+		func(_ context.Context, input int) (int, error) { return input + 1, secondErr },
+	)
+	workflow := NewWorkflow("workflow", first, second)
+	workflow.SetRunPlan(first, RunPlan[int]{Failure: second})
+
+	output, err := workflow.Run(context.Background(), 0)
+
+	assert.Error(t, err)
+	assert.Equal(t, 2, output)
+	assert.Contains(t, err.Error(), firstErr.Error())
+	assert.Contains(t, err.Error(), secondErr.Error())
+	assert.Less(t, strings.Index(err.Error(), firstErr.Error()), strings.Index(err.Error(), secondErr.Error()))
 }


### PR DESCRIPTION
## Problem

Some action wrappers were losing useful error information:

* SequenceSliceAction and SequenceMapAction overwrote earlier errors when multiple items failed.
* If a sequential action had already collected an error and then later panicked, the panic recovery replaced the previous error.
* Workflow.RunAt only returned the last action error, even when a workflow intentionally followed failure paths and multiple actions failed in order.
* SimpleBranchAction stored and returned the directions slice directly, allowing external mutation to change branch behavior after construction.

## Changes

* Updated SequenceSliceAction and SequenceMapAction to accumulate errors with errors.Join.
* Wrapped sequence item errors with index/key context:
  * slice: error occurred at index N
  * map: error occurred at key ...
* Preserved already-collected sequence errors when panic recovery runs.
* Updated Workflow.RunAt to accumulate action errors in execution order instead of keeping only the last one.
* Changed SimpleBranchAction to defensively copy directions on construction and when returning Directions().

## Tests

Added coverage for:

* Multiple sequence slice errors being joined in index order.
* Sequence slice preserving earlier errors when a later item panics.
* Multiple sequence map errors being joined without relying on map iteration order.
* SimpleBranchAction directions being protected from external mutation.
* Workflow.RunAt returning multiple action errors in execution order.